### PR TITLE
feat(selinux): ujust purge-stale-snap-selinux to clear stale snap policy modules

### DIFF
--- a/mods/just/60-dx4homelab.just
+++ b/mods/just/60-dx4homelab.just
@@ -65,3 +65,60 @@ install-extra-ca-trust dir="~/.config/dx4homelab/ca-anchors":
     sudo update-ca-trust
     echo "✓ Installed ${installed} CA cert(s) into the system trust."
     echo "  Verify: trust list --filter=ca-anchors | grep -i '<your CA CN>'"
+
+# Remove a stale, locally-installed (priority 400) snap SELinux override — e.g. a
+# `snapd_local` module produced by audit2allow. After a base `selinux-policy` bump, such
+# a local module can reference types/attributes the new base no longer defines (e.g.
+# `snappy_t`); then `ostree-finalize-staged` fails to rebuild the SELinux policy and the
+# next image update can't finalize or boot. snapd itself ships in the upstream bluefin
+# image (not added here) and is NOT touched — only the local priority-400 override is
+# removed; snapd's packaged `snappy` policy (priority 200) stays. Any allows you actually
+# need can be regenerated with audit2allow against the *new* policy after updating.
+# Idempotent: a clean no-op when nothing matches. Because snapd ships upstream, pass
+# `force` to confirm removal while the snapd package is installed.
+# Usage:  ujust purge-stale-snap-selinux [force]
+[group('dx4homelab')]
+purge-stale-snap-selinux force="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v semodule >/dev/null 2>&1; then
+        echo "semodule not found — SELinux tooling unavailable; nothing to do."
+        exit 0
+    fi
+    # Priority 400 = locally installed (semodule -i) modules; image modules live at 100.
+    # Match snapd*/snappy* only — NOT 'snapper' (the unrelated btrfs snapshot tool).
+    mapfile -t stale < <(sudo semodule -lfull | awk '$1==400 && tolower($2) ~ /^snap(d|py)/ {print $2}')
+    if [[ ${#stale[@]} -eq 0 ]]; then
+        echo "✓ No stale priority-400 snap SELinux modules found — nothing to do."
+        exit 0
+    fi
+    echo "Found local (priority 400) snap SELinux module(s):"
+    printf '    %s\n' "${stale[@]}"
+    if rpm -q snapd >/dev/null 2>&1 && [[ "{{force}}" != "force" ]]; then
+        echo "" >&2
+        echo "! The 'snapd' package IS installed — these modules may still be in use." >&2
+        echo "  Refusing to remove them without an explicit override. If you really want" >&2
+        echo "  to drop snapd's SELinux modules anyway, re-run:" >&2
+        echo "      ujust purge-stale-snap-selinux force" >&2
+        exit 1
+    fi
+    removed=0
+    for m in "${stale[@]}"; do
+        # Try a normal removal (also reloads the live policy). If the live reload
+        # fails, fall back to --noreload (-N): the store is still cleaned, and the
+        # next ostree finalize rebuilds the policy without the module.
+        if sudo semodule -X 400 -r "$m" 2>/dev/null; then
+            echo "  + removed: $m"
+            removed=$((removed + 1))
+        elif sudo semodule -N -X 400 -r "$m"; then
+            echo "  + removed (store only; policy rebuilds on next boot): $m"
+            removed=$((removed + 1))
+        else
+            echo "  ! failed to remove: $m" >&2
+        fi
+    done
+    [[ $removed -gt 0 ]] || { echo "No modules removed." >&2; exit 1; }
+    echo "✓ Removed ${removed} stale snap SELinux module(s)."
+    echo "  Re-stage and boot the pending update so its SELinux policy finalizes cleanly:"
+    echo "      sudo rpm-ostree update && sudo systemctl reboot"
+    echo "  After reboot, confirm with: rpm-ostree status"


### PR DESCRIPTION
## What

Adds a `ujust purge-stale-snap-selinux` recipe that detects and removes a stale, locally-installed (priority 400) snap SELinux module — e.g. a `snapd_local` module produced by `audit2allow`.

## Why

A local priority-400 snap module can reference SELinux types the base policy later drops (e.g. `snappy_t` after an `selinux-policy` bump). On the next image update, `ostree-finalize-staged` then fails to rebuild the policy and the deployment can't finalize or boot:

```
Failed to resolve typeattributeset statement at .../400/snapd_local/cil:2
error: Finalizing deployment: Finalizing SELinux policy: ... exited with code 1
```

This happened on `minis4dx` updating to `7c4818f`: a hand-built `snapd_local` module (audit2allow, granting `snappy_t` extra access to `var_t`/`var_lib_t`/`spc_t`, created Jun 11) required `snappy_t`, which the new image's policy no longer defines — blocking finalize. Note this was **not** caused by any repo build change; it was local SELinux state on the host.

## How

- Lists priority-400 modules whose name matches `snapd*`/`snappy*` (deliberately excludes the unrelated `snapper` btrfs module).
- No-op when nothing matches; safe to run on any machine.
- Leaves snapd (upstream image content) and its packaged `snappy` policy (priority 200) intact — only the local priority-400 override is removed.
- Requires `force` to act while the `snapd` package is installed (snapd ships upstream), so removal is a conscious choice.
- Falls back to `semodule -N` (no live reload) if the live policy reload fails, so the store is still cleaned and the next ostree finalize rebuilds without the module.

Wired into the dx image via the existing `mods/just` → `60-custom.just` `EXTRA_FILE_COPIES` path in `customize-build.py`, so it's auto-imported as a `ujust` recipe on the next build.

## Validation

- `just --justfile mods/just/60-dx4homelab.just --list` parses; recipe shows under the `dx4homelab` group with signature `purge-stale-snap-selinux force=""`.
- `bash -n` clean for both `force=""` and `force=force`.
- Matcher verified to hit `snapd_local`/`snappy_local` (priority 400) and skip `snapper`.
- Exercised live on `minis4dx`: removed the offending `snapd_local`; `semodule -B` then rebuilds the policy store cleanly — the exact step finalize was failing on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
